### PR TITLE
Use a separate tsconfig.json for the express app

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "volleyball": "^1.5.1"
   },
   "scripts": {
-    "start": "ts-node ./server/server.ts & react-scripts start",
+    "start:server": "ts-node --project tsconfig.server.json ./server/server.ts",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "target": "es6",
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "outDir": "dist",
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "node_modules/*",
+                "src/types/*"
+            ]
+        }
+    },
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
Now you get a no implicit any error. 

Note: This isn't the entirety of the changes you'll want to make, you probably don't want them to build to the same dist folder either (since the react js should be public and the server side should not).
Since the react build process and the node express process are different, you'll now need to run two commands to kick them both off - `yarn run start:server` in one window and `yarn start` in another. Using `&&` doesn't work because the server script doesn't return until it's shut down. You can simplify this using something like `npm-run-all` or `concurrently` to get back down to one command. 
 
